### PR TITLE
disable mount/umount2 for /proc in qemu-vroot, make `apk update` runnable

### DIFF
--- a/build-hnp/qemu-vroot/0011-Disable-mount-proc-filesystem.patch
+++ b/build-hnp/qemu-vroot/0011-Disable-mount-proc-filesystem.patch
@@ -1,0 +1,46 @@
+From bd66045ded34a1923f81d5e4e9203d0bb6bdb9b3 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Thu, 10 Jul 2025 00:45:05 +0800
+Subject: [PATCH 11/12] Disable mount proc filesystem
+
+---
+ linux-user/syscall.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 85c85fa..af27339 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -6127,6 +6127,17 @@ static int do_execve(char *p, const char **argp, const char **envp) {
+     return ret;
+ }
+ 
++static int do_mount(const char *source, const char *target,
++                 const char *filesystemtype, unsigned long mountflags,
++                 const void * data) {
++
++    if (strcmp(filesystemtype, "proc") == 0) {
++        return -EPERM;
++    }
++
++    return mount(source, target, filesystemtype, mountflags, data);
++}
++
+ /* warning : doesn't handle linux specific flags... */
+ static int target_to_host_fcntl_cmd(int cmd)
+ {
+@@ -8053,9 +8064,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+              * string.
+              */
+             if (!arg5) {
+-                ret = mount(p, p2, p3, (unsigned long)arg4, NULL);
++                ret = do_mount(p, p2, p3, (unsigned long)arg4, NULL);
+             } else {
+-                ret = mount(p, p2, p3, (unsigned long)arg4, g2h(arg5));
++                ret = do_mount(p, p2, p3, (unsigned long)arg4, g2h(arg5));
+             }
+             ret = get_errno(ret);
+ 
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/0012-Disable-umount2-proc-filesystem.patch
+++ b/build-hnp/qemu-vroot/0012-Disable-umount2-proc-filesystem.patch
@@ -1,0 +1,41 @@
+From 346222136ac8adff40b8987842933d0d4c962feb Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Thu, 10 Jul 2025 01:05:36 +0800
+Subject: [PATCH 12/12] Disable umount2 proc filesystem
+
+---
+ linux-user/syscall.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index af27339..f762e2b 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -6138,6 +6138,15 @@ static int do_mount(const char *source, const char *target,
+     return mount(source, target, filesystemtype, mountflags, data);
+ }
+ 
++static int do_umount2(const char *target, int flags) {
++
++    if (strstr(target, "/proc") != NULL) {
++        return -EPERM;
++    }
++
++    return umount2(target, flags);
++}
++
+ /* warning : doesn't handle linux specific flags... */
+ static int target_to_host_fcntl_cmd(int cmd)
+ {
+@@ -8321,7 +8330,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+     case TARGET_NR_umount2:
+         if (!(p = lock_user_string(arg1)))
+             return -TARGET_EFAULT;
+-        ret = get_errno(umount2(p, arg2));
++        ret = get_errno(do_umount2(p, arg2));
+         unlock_user(p, arg1, 0);
+         return ret;
+ #endif
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -13,6 +13,8 @@ all: download/qemu-5.0
 	cd temp/qemu-5.0 && git apply ../../0007-Find-qemu-abs-path-from-proc-self-exe-instead.patch
 	cd temp/qemu-5.0 && git apply ../../0009-Refactor-vroot-path-resolving.patch
 	cd temp/qemu-5.0 && git apply ../../0010-Support-specify-relative-virtual-root-directory.patch
+	cd temp/qemu-5.0 && git apply ../../0011-Disable-mount-proc-filesystem.patch
+	cd temp/qemu-5.0 && git apply ../../0012-Disable-umount2-proc-filesystem.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \


### PR DESCRIPTION
Before that, `apk update` with `qemu-vroot-aarch64` will be killed after `mount` and `umount2` for proc filesystem.