### PR TITLE
Support shebang in execve syscall for qemu-vroot

### DIFF
--- a/build-hnp/qemu-vroot/0014-Support-shebang-in-execve-syscall.patch
+++ b/build-hnp/qemu-vroot/0014-Support-shebang-in-execve-syscall.patch
@@ -1,0 +1,455 @@
+From f706fadaa93bcaac1c52aad9b63a99e34146ab0f Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sat, 12 Jul 2025 11:25:17 +0800
+Subject: [PATCH 14/14] Support shebang in execve syscall
+
+---
+ .gitignore           |   3 +-
+ linux-user/execve.c  | 192 ++++++++++++++++++++++++++++++++++++++++++-
+ linux-user/execve.h  |  17 +++-
+ linux-user/syscall.c |  99 +++++++++++++++++-----
+ util/path.c          |  14 +++-
+ 5 files changed, 297 insertions(+), 28 deletions(-)
+
+diff --git a/.gitignore b/.gitignore
+index b4469d8..8ed92ea 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -162,4 +162,5 @@ trace-ust-all.h
+ trace-ust-all.c
+ /target/arm/decode-sve.inc.c
+
+-build
+\ No newline at end of file
++build
++release
+\ No newline at end of file
+diff --git a/linux-user/execve.c b/linux-user/execve.c
+index efc3b71..b0a9a4e 100644
+--- a/linux-user/execve.c
++++ b/linux-user/execve.c
+@@ -4,6 +4,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <assert.h>
++#include <errno.h>
++#include <fcntl.h>
+ #include <unistd.h>
+ #include <linux/limits.h>
+
+@@ -39,10 +41,7 @@ const char *get_qemu_abs_path(void) {
+     return qemu_abs_path;
+ }
+
+-const char **get_qemu_argv_prefix(int *pn_argv_prefix) {
+-    if (pn_argv_prefix != NULL) {
+-        *pn_argv_prefix = n_argv_prefix;
+-    }
++const char **get_qemu_argv_prefix(void) {
+     return argv_prefix;
+ }
+
+@@ -57,3 +56,188 @@ const char *find_path_env_value(const char **envp) {
+         return NULL;
+     }
+ }
++
++const char *resolve_program_path(const char *p, const char **envp) {
++
++    const char* new_program_path = NULL;
++    if (p[0] != '/' && p[0] != '.') {
++        const char* path_value = find_path_env_value(envp);
++        if (path_value != NULL) {
++            char prog[PATH_MAX] = {0};
++            if (resolve_with_path_env(path_value, p, prog)) {
++                new_program_path = path(prog);
++            }
++        }
++    }
++    if (new_program_path == NULL) {
++        new_program_path = path(p);
++    }
++
++    return new_program_path;
++}
++
++int size_of_vp(const char** vp) {
++	int c = 0;
++	while (vp[c] != NULL) { c++; };
++	return c;
++}
++
++bool is_elf(const char *buff) {
++    return buff[0] == 0x7f && buff[1] == 0x45 && buff[2] == 0x4c && buff[3] == 0x46;
++}
++
++bool is_shebang(const char *buff) {
++    return buff[0] == '#' && buff[1] == '!';
++}
++
++/**
++ * copied and modified from proot
++ */
++int extract_shebang(const char *host_path,
++                    char user_path[PATH_MAX], char argument[BINPRM_BUF_SIZE])
++{
++	char tmp2[2];
++	char tmp;
++
++	size_t current_length;
++	size_t i;
++
++	int status;
++	int fd;
++
++	/* Assumption.  */
++	assert(BINPRM_BUF_SIZE < PATH_MAX);
++
++	argument[0] = '\0';
++
++	/* Inspect the executable.  */
++	fd = open(host_path, O_RDONLY);
++	if (fd < 0)
++		return -errno;
++
++	status = read(fd, tmp2, 2 * sizeof(char));
++	if (status < 0) {
++		status = -errno;
++		goto end;
++	}
++	if ((size_t) status < 2 * sizeof(char)) { /* EOF */
++		status = 0;
++		goto end;
++	}
++
++	/* Check if it really is a script text. */
++	if (tmp2[0] != '#' || tmp2[1] != '!') {
++		status = 0;
++		goto end;
++	}
++	current_length = 2;
++	user_path[0] = '\0';
++
++	/* Skip leading spaces. */
++	do {
++		status = read(fd, &tmp, sizeof(char));
++		if (status < 0) {
++			status = -errno;
++			goto end;
++		}
++		if ((size_t) status < sizeof(char)) { /* EOF */
++			status = -ENOEXEC;
++			goto end;
++		}
++
++		current_length++;
++	} while ((tmp == ' ' || tmp == '\t') && current_length < BINPRM_BUF_SIZE);
++
++	/* Slurp the interpreter path until the first space or end-of-line. */
++	for (i = 0; current_length < BINPRM_BUF_SIZE; current_length++, i++) {
++		switch (tmp) {
++		case ' ':
++		case '\t':
++			/* Remove spaces in between the interpreter
++			 * and the hypothetical argument. */
++			user_path[i] = '\0';
++			break;
++
++		case '\n':
++		case '\r':
++			/* There is no argument. */
++			user_path[i] = '\0';
++			argument[0] = '\0';
++			status = 1;
++			goto end;
++
++		default:
++			/* There is an argument if the previous
++			 * character in user_path[] is '\0'. */
++			if (i > 1 && user_path[i - 1] == '\0')
++				goto argument;
++			else
++				user_path[i] = tmp;
++			break;
++		}
++
++		status = read(fd, &tmp, sizeof(char));
++		if (status < 0) {
++			status = -errno;
++			goto end;
++		}
++		if ((size_t) status < sizeof(char)) { /* EOF */
++			user_path[i] = '\0';
++			argument[0] = '\0';
++			status = 1;
++			goto end;
++		}
++	}
++
++	/* The interpreter path is too long, truncate it. */
++	user_path[i] = '\0';
++	argument[0] = '\0';
++	status = 1;
++	goto end;
++
++argument:
++
++	/* Slurp the argument until the end-of-line. */
++	for (i = 0; current_length < BINPRM_BUF_SIZE; current_length++, i++) {
++		switch (tmp) {
++		case '\n':
++		case '\r':
++			argument[i] = '\0';
++
++			/* Remove trailing spaces. */
++			for (i--; i > 0 && (argument[i] == ' ' || argument[i] == '\t'); i--)
++				argument[i] = '\0';
++
++			status = 1;
++			goto end;
++
++		default:
++			argument[i] = tmp;
++			break;
++		}
++
++		status = read(fd, &tmp, sizeof(char));
++		if (status < 0) {
++			status = -errno;
++			goto end;
++		}
++		if ((size_t) status < sizeof(char)) { /* EOF */
++			argument[0] = '\0';
++			status = 1;
++			goto end;
++		}
++	}
++
++	/* The argument is too long, truncate it. */
++	argument[i] = '\0';
++	status = 1;
++
++end:
++	close(fd);
++
++	/* Did an error occur or isn't a script? */
++	if (status <= 0)
++		return status;
++
++	return 1;
++}
+\ No newline at end of file
+diff --git a/linux-user/execve.h b/linux-user/execve.h
+index a9c1169..ebc3bff 100644
+--- a/linux-user/execve.h
++++ b/linux-user/execve.h
+@@ -1,12 +1,27 @@
+ #ifndef _EXECVE_H
+ #define _EXECVE_H
++#include <stdbool.h>
++#include <linux/limits.h>
++
++#define BINPRM_BUF_SIZE 256
+
+ void setup_for_execve(const char** argv, int optind);
+
+ const char* get_qemu_abs_path(void);
+-const char** get_qemu_argv_prefix(int* n_prefix);
++const char** get_qemu_argv_prefix(void);
+
+ //  find value of PATH env variable in envp
+ const char *find_path_env_value(const char **envp);
+
++const char *resolve_program_path(const char *p, const char **envp);
++
++int size_of_vp(const char** vp);
++
++bool is_elf(const char *buff);
++
++bool is_shebang(const char *buff);
++
++int extract_shebang(const char *host_path,
++        char user_path[PATH_MAX], char argument[BINPRM_BUF_SIZE]);
++
+ #endif
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 4c317e7..efd2390 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -20,6 +20,7 @@
+ #include "qemu/osdep.h"
+ #include "qemu/cutils.h"
+ #include "qemu/path.h"
++#include "execve.h"
+ #include "qemu/memfd.h"
+ #include "qemu/queue.h"
+ #include <elf.h>
+@@ -6091,35 +6092,71 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
+     return ret;
+ }
+
+-static int do_execve(char *p, const char **argp, const char **envp) {
+-
+-    int argc = 0;
+-    while (argp[argc] != NULL) { argc++; }
++static int execve_elf(const char *program, const char **argv, const char **envp) {
+
+     const char* qemu = get_qemu_abs_path();
+
+-    int n_prefix = 0;
+-    const char** argv_prefix = get_qemu_argv_prefix(&n_prefix);
++    int original_argc = size_of_vp(argv);
+
+-    const char **new_argv = g_new0(char *, n_prefix + argc + 1);
++    const char** argv_prefix = get_qemu_argv_prefix();
++    int n_prefix = size_of_vp(argv_prefix);
++
++    const char **new_argv = g_new0(char *, n_prefix + original_argc + 1);
+     memcpy(new_argv, argv_prefix, n_prefix * sizeof(char*));
+-    memcpy(&new_argv[n_prefix], argp, (argc + 1) * sizeof(char *));
++    memcpy(&new_argv[n_prefix], argv, (original_argc + 1) * sizeof(char *));
+
+     int idx_guest_program = n_prefix;
+-    if (new_argv[idx_guest_program][0] != '/') {
++    new_argv[idx_guest_program] = program;
+
+-        const char* path_value = find_path_env_value(envp);
++    int ret = safe_execve(qemu, new_argv, envp);
++
++    g_free(new_argv);
++
++    return ret;
++}
++
++int execve_shebang(const char *filepath, const char **argv, const char **envp) {
++
++    char user_path[PATH_MAX] = {0};
++    char argument[BINPRM_BUF_SIZE] = {0};
++
++    if (extract_shebang(filepath, user_path, argument) < 0) {
++        errno = ENOEXEC;
++        return -1;
++    }
++
++    const char* program = path(user_path);
++
++    const char* qemu = get_qemu_abs_path();
++
++    int original_argc = size_of_vp(argv);
++
++    const char** argv_prefix = get_qemu_argv_prefix();
++    int n_prefix = size_of_vp(argv_prefix);
++
++    const char **new_argv;
++    if (argument[0] != '\0') {
++
++        new_argv = g_new0(char *, n_prefix + 2 + original_argc + 1);
++
++        memcpy(new_argv, argv_prefix, n_prefix * sizeof(char*));
++
++        new_argv[n_prefix + 0] = program;
++        new_argv[n_prefix + 1] = argument;
++        new_argv[n_prefix + 2] = filepath;
++
++        memcpy(&new_argv[n_prefix + 3], argv + 1, original_argc * sizeof(char *));
+
+-        if (path_value != NULL) {
+-            char prog[PATH_MAX] = {0};
+-            if (resolve_with_path_env(path_value, new_argv[idx_guest_program], prog)) {
+-                new_argv[idx_guest_program] = path(prog);
+-            } else {
+-                new_argv[idx_guest_program] = path(p);
+-            }
+-        }
+     } else {
+-        new_argv[idx_guest_program] = path(new_argv[idx_guest_program]);
++
++        new_argv = g_new0(char *, n_prefix + 1 + original_argc + 1);
++
++        memcpy(new_argv, argv_prefix, n_prefix * sizeof(char*));
++
++        new_argv[n_prefix + 0] = program;
++        new_argv[n_prefix + 1] = filepath;
++
++        memcpy(&new_argv[n_prefix + 2], argv + 1, original_argc * sizeof(char *));
+     }
+
+     int ret = safe_execve(qemu, new_argv, envp);
+@@ -6129,6 +6166,30 @@ static int do_execve(char *p, const char **argp, const char **envp) {
+     return ret;
+ }
+
++static int do_execve(char *p, const char **argp, const char **envp) {
++
++    const char* new_program_path = resolve_program_path(p, envp);
++
++    int prog_fd = open(new_program_path, O_RDONLY);
++    if (prog_fd < 0) {
++        return -1;
++    }
++    char buff[4];
++    if (read(prog_fd, buff, 4) < 4) {
++        errno = ENOEXEC;
++        return -1;
++    }
++
++    if (is_elf(buff)) {
++        return execve_elf(new_program_path, argp, envp);
++    } else if (is_shebang(buff)) {
++        return execve_shebang(new_program_path, argp, envp);
++    } else {
++        errno = ENOEXEC;
++        return -1;
++    }
++}
++
+ static int do_mount(const char *source, const char *target,
+                  const char *filesystemtype, unsigned long mountflags,
+                  const void * data) {
+diff --git a/util/path.c b/util/path.c
+index 3535851..fb68d5a 100644
+--- a/util/path.c
++++ b/util/path.c
+@@ -21,13 +21,18 @@ void init_paths(const char *prefix)
+         return;
+     }
+
++    char* tmp_base;
+     if (prefix[0] == '/') {
+-        base = g_strdup(prefix);
++        tmp_base = g_strdup(prefix);
+     } else {
+         char *cwd = g_get_current_dir();
+-        base = g_build_filename(cwd, prefix, NULL);
++        tmp_base = g_build_filename(cwd, prefix, NULL);
+         g_free(cwd);
+     }
++    char* real = calloc(PATH_MAX, sizeof(char));
++    realpath(tmp_base, real);
++    free(tmp_base);
++    base = real;
+
+     hash = g_hash_table_new(g_str_hash, g_str_equal);
+     qemu_mutex_init(&lock);
+@@ -42,7 +47,7 @@ static const char *relocate_path(const char *name, bool keep_relative_path)
+     char abspath[PATH_MAX];
+
+     if (!base || !name) {
+-        //  rnvalid
++        //  invalid
+         return name;
+     } else if (strcmp(name, "/") == 0) {
+         //  root
+@@ -65,6 +70,9 @@ static const char *relocate_path(const char *name, bool keep_relative_path)
+             || strcmp(name, "/etc/resolv.conf") == 0) {
+             //  reuse hosts
+             return name;
++        } else if (strstr(name, base) == name) {
++            //  already at rootfs
++            return name;
+         }
+         strcpy(abspath, name);
+     }
+--
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -16,6 +16,7 @@ all: download/qemu-5.0
 	cd temp/qemu-5.0 && git apply ../../0011-Disable-mount-proc-filesystem.patch
 	cd temp/qemu-5.0 && git apply ../../0012-Disable-umount2-proc-filesystem.patch
 	cd temp/qemu-5.0 && git apply ../../0013-Complete-path-relocation.patch
+	cd temp/qemu-5.0 && git apply ../../0014-Support-shebang-in-execve-syscall.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \


### PR DESCRIPTION
Support loading and running script start with `#!` in execve syscall

![d03cb6878ac25959013a5661e76b9201](https://github.com/user-attachments/assets/f1ac4e14-dd16-4d09-a090-f9fae60cabe3)
