### PR TITLE
Fix some errors to enable gcc in qemu-vroot

### DIFF
--- a/build-hnp/qemu-vroot/0024-Complete-tcg_qemu_tb_exec-for-unimplemented-TCGOpcod.patch
+++ b/build-hnp/qemu-vroot/0024-Complete-tcg_qemu_tb_exec-for-unimplemented-TCGOpcod.patch
@@ -1,0 +1,66 @@
+From 687a472c71161b5cb100cdd772541a6d080eab5e Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Fri, 18 Jul 2025 22:28:44 +0800
+Subject: [PATCH 24/24] Complete tcg_qemu_tb_exec for unimplemented TCGOpcode
+
+---
+ tcg/tci.c | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/tcg/tci.c b/tcg/tci.c
+index 46fe9ce..88d3dd3 100644
+--- a/tcg/tci.c
++++ b/tcg/tci.c
+@@ -591,13 +591,22 @@ uintptr_t tcg_qemu_tb_exec(CPUArchState *env, uint8_t *tb_ptr)
+             tci_write_reg8(regs, t0, *(uint8_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld8s_i32:
+-            TODO();
++            t0 = *tb_ptr++;
++            t1 = tci_read_r(regs, &tb_ptr);
++            t2 = tci_read_s32(&tb_ptr);
++            tci_write_reg8(regs, t0, *(int8_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld16u_i32:
+-            TODO();
++            t0 = *tb_ptr++;
++            t1 = tci_read_r(regs, &tb_ptr);
++            t2 = tci_read_s32(&tb_ptr);
++            tci_write_reg16(regs, t0, *(uint16_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld16s_i32:
+-            TODO();
++            t0 = *tb_ptr++;
++            t1 = tci_read_r(regs, &tb_ptr);
++            t2 = tci_read_s32(&tb_ptr);
++            tci_write_reg16(regs, t0, *(int16_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld_i32:
+             t0 = *tb_ptr++;
+@@ -862,7 +871,10 @@ uintptr_t tcg_qemu_tb_exec(CPUArchState *env, uint8_t *tb_ptr)
+             tci_write_reg8(regs, t0, *(uint8_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld8s_i64:
+-            TODO();
++            t0 = *tb_ptr++;
++            t1 = tci_read_r(regs, &tb_ptr);
++            t2 = tci_read_s32(&tb_ptr);
++            tci_write_reg8(regs, t0, *(int8_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld16u_i64:
+             t0 = *tb_ptr++;
+@@ -871,7 +883,10 @@ uintptr_t tcg_qemu_tb_exec(CPUArchState *env, uint8_t *tb_ptr)
+             tci_write_reg16(regs, t0, *(uint16_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld16s_i64:
+-            TODO();
++            t0 = *tb_ptr++;
++            t1 = tci_read_r(regs, &tb_ptr);
++            t2 = tci_read_s32(&tb_ptr);
++            tci_write_reg16(regs, t0, *(int16_t *)(t1 + t2));
+             break;
+         case INDEX_op_ld32u_i64:
+             t0 = *tb_ptr++;
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/0025-Fix-target-madvise.patch
+++ b/build-hnp/qemu-vroot/0025-Fix-target-madvise.patch
@@ -1,0 +1,308 @@
+From 504a47c44749f6a7bbfc2eae6772710b3635fb95 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sat, 19 Jul 2025 10:37:07 +0800
+Subject: [PATCH 25/27] Fix target madvise
+
+reference: https://github.com/qemu/qemu/commit/892a4f6a750abceeda4c1ee8324f58f82fd6bd89
+---
+ accel/tcg/translate-all.c |  8 +---
+ bsd-user/mmap.c           |  8 ++--
+ include/exec/cpu-all.h    |  9 +---
+ linux-user/elfload.c      |  2 +-
+ linux-user/mmap.c         | 90 ++++++++++++++++++++++++++-------------
+ linux-user/qemu.h         |  2 +-
+ linux-user/syscall.c      | 10 +++--
+ 7 files changed, 75 insertions(+), 54 deletions(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index b7cccc3..45b1918 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -2491,8 +2491,7 @@ int page_get_flags(target_ulong address)
+ /* Modify the flags of a page and invalidate the code if necessary.
+    The flag PAGE_WRITE_ORG is positioned automatically depending
+    on PAGE_WRITE.  The mmap_lock should already be held.  */
+-void page_set_flags(target_ulong start, target_ulong end, int flags,
+-                    enum page_set_flags_mode mode)
++void page_set_flags(target_ulong start, target_ulong end, int flags)
+ {
+     target_ulong addr, len;
+ 
+@@ -2524,10 +2523,7 @@ void page_set_flags(target_ulong start, target_ulong end, int flags,
+             p->first_tb) {
+             tb_invalidate_phys_page(addr, 0);
+         }
+-        if (mode == PAGE_SET_ALL_FLAGS)
+-            p->flags = flags;
+-        else /* PAGE_SET_PROTECTION */
+-            p->flags |= (p->flags & ~(PAGE_BITS - 1)) | (flags & PAGE_BITS);
++        p->flags = flags;
+     }
+ }
+ 
+diff --git a/bsd-user/mmap.c b/bsd-user/mmap.c
+index 4bfac81..17f4cd8 100644
+--- a/bsd-user/mmap.c
++++ b/bsd-user/mmap.c
+@@ -125,7 +125,7 @@ int target_mprotect(abi_ulong start, abi_ulong len, int prot)
+         if (ret != 0)
+             goto error;
+     }
+-    page_set_flags(start, start + len, prot, PAGE_SET_PROTECTION);
++    page_set_flags(start, start + len, prot | PAGE_VALID);
+     mmap_unlock();
+     return 0;
+ error:
+@@ -214,7 +214,7 @@ static abi_ulong mmap_find_vma(abi_ulong start, abi_ulong size)
+            to mmap.  */
+         page_set_flags(last_brk & TARGET_PAGE_MASK,
+                        TARGET_PAGE_ALIGN(new_brk),
+-                       PAGE_RESERVED, PAGE_SET_ALL_FLAGS);
++                       PAGE_RESERVED);
+     }
+     last_brk = new_brk;
+ 
+@@ -397,7 +397,7 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int prot,
+         }
+     }
+  the_end1:
+-    page_set_flags(start, start + len, prot | PAGE_VALID, PAGE_SET_ALL_FLAGS);
++    page_set_flags(start, start + len, prot | PAGE_VALID);
+  the_end:
+ #ifdef DEBUG_MMAP
+     printf("ret=0x" TARGET_FMT_lx "\n", start);
+@@ -460,7 +460,7 @@ int target_munmap(abi_ulong start, abi_ulong len)
+     }
+ 
+     if (ret == 0)
+-        page_set_flags(start, start + len, 0, PAGE_SET_ALL_FLAGS);
++        page_set_flags(start, start + len, 0);
+     mmap_unlock();
+     return ret;
+ }
+diff --git a/include/exec/cpu-all.h b/include/exec/cpu-all.h
+index 8673a79..6ba0870 100644
+--- a/include/exec/cpu-all.h
++++ b/include/exec/cpu-all.h
+@@ -264,7 +264,6 @@ extern intptr_t qemu_host_page_mask;
+ #if defined(CONFIG_LINUX) && defined(CONFIG_USER_ONLY)
+ #define PAGE_MAP_ANONYMOUS 0x0080
+ #endif
+-
+ #if defined(CONFIG_USER_ONLY)
+ void page_dump(FILE *f);
+ 
+@@ -272,14 +271,8 @@ typedef int (*walk_memory_regions_fn)(void *, target_ulong,
+                                       target_ulong, unsigned long);
+ int walk_memory_regions(void *, walk_memory_regions_fn);
+ 
+-enum page_set_flags_mode {
+-    PAGE_SET_ALL_FLAGS,
+-    PAGE_SET_PROTECTION
+-};
+-
+ int page_get_flags(target_ulong address);
+-void page_set_flags(target_ulong start, target_ulong end, int flags,
+-                   enum page_set_flags_mode mode);
++void page_set_flags(target_ulong start, target_ulong end, int flags);
+ int page_check_range(target_ulong start, target_ulong len, int flags);
+ #endif
+ 
+diff --git a/linux-user/elfload.c b/linux-user/elfload.c
+index 9a54189..b6e5e63 100644
+--- a/linux-user/elfload.c
++++ b/linux-user/elfload.c
+@@ -1847,7 +1847,7 @@ static void zero_bss(abi_ulong elf_bss, abi_ulong last_bss, int prot)
+ 
+     /* Ensure that the bss page(s) are valid */
+     if ((page_get_flags(last_bss-1) & prot) != prot) {
+-        page_set_flags(elf_bss & TARGET_PAGE_MASK, last_bss, prot, PAGE_SET_PROTECTION);
++        page_set_flags(elf_bss & TARGET_PAGE_MASK, last_bss, prot | PAGE_VALID);
+     }
+ 
+     if (host_start < host_map_start) {
+diff --git a/linux-user/mmap.c b/linux-user/mmap.c
+index 1af082a..54e0ac5 100644
+--- a/linux-user/mmap.c
++++ b/linux-user/mmap.c
+@@ -116,7 +116,7 @@ int target_mprotect(abi_ulong start, abi_ulong len, int prot)
+         if (ret != 0)
+             goto error;
+     }
+-    page_set_flags(start, start + len, prot, PAGE_SET_PROTECTION);
++    page_set_flags(start, start + len, prot | PAGE_VALID);
+     mmap_unlock();
+     return 0;
+ error:
+@@ -544,7 +544,7 @@ abi_long target_mmap(abi_ulong start, abi_ulong len, int prot,
+     if (flags & MAP_ANONYMOUS) {
+         page_flags |= PAGE_MAP_ANONYMOUS;
+     }
+-    page_set_flags(start, start + len, page_flags, PAGE_SET_ALL_FLAGS);
++    page_set_flags(start, start + len, page_flags);
+  the_end:
+     trace_target_mmap_complete(start);
+     if (qemu_loglevel_mask(CPU_LOG_PAGE)) {
+@@ -653,7 +653,7 @@ int target_munmap(abi_ulong start, abi_ulong len)
+     }
+ 
+     if (ret == 0) {
+-        page_set_flags(start, start + len, 0, PAGE_SET_ALL_FLAGS);
++        page_set_flags(start, start + len, 0);
+         tb_invalidate_phys_range(start, start + len);
+     }
+     mmap_unlock();
+@@ -733,44 +733,74 @@ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
+     } else {
+         new_addr = h2g(host_addr);
+         prot = page_get_flags(old_addr);
+-        page_set_flags(old_addr, old_addr + old_size, 0,
+-                       PAGE_SET_ALL_FLAGS);
+-        page_set_flags(new_addr, new_addr + new_size, prot | PAGE_VALID,
+-                       PAGE_SET_ALL_FLAGS);
++        page_set_flags(old_addr, old_addr + old_size, 0);
++        page_set_flags(new_addr, new_addr + new_size, prot | PAGE_VALID);
+     }
+     tb_invalidate_phys_range(new_addr, new_addr + new_size);
+     mmap_unlock();
+     return new_addr;
+ }
+ 
+-int target_madvise(abi_ulong start, abi_ulong len, int advice)
++static bool can_passthrough_madv_dontneed(abi_ulong start, abi_ulong end)
+ {
+-    abi_ulong end, addr;
+-    int ret;
++    ulong addr;
+ 
+-    len = TARGET_PAGE_ALIGN(len);
+-    start &= TARGET_PAGE_MASK;
++    if ((start | end) & ~qemu_host_page_mask) {
++        return false;
++    }
++
++    for (addr = start; addr < end; addr += TARGET_PAGE_SIZE) {
++        if (!(page_get_flags(addr) & PAGE_MAP_ANONYMOUS)) {
++            return false;
++        }
++    }
++
++    return true;
++}
++
++abi_long target_madvise(abi_ulong start, abi_ulong len_in, int advice)
++{
++    abi_ulong len, end;
++    int ret = 0;
++
++    if (start & ~TARGET_PAGE_MASK) {
++        return -TARGET_EINVAL;
++    }
++    len = TARGET_PAGE_ALIGN(len_in);
++
++    if (len_in && !len) {
++        return -TARGET_EINVAL;
++    }
++
++    end = start + len;
++    if (end < start) {
++        return -TARGET_EINVAL;
++    }
++
++    if (end == start) {
++        return 0;
++    }
+ 
+     if (!guest_range_valid(start, len)) {
+-        errno = EINVAL;
+-        return -1;
++        return -TARGET_EINVAL;
+     }
+ 
+-    /* A straight passthrough may not be safe because qemu sometimes
+-       turns private file-backed mappings into anonymous mappings.
+-       Most flags are hints so we ignore them.
+-       One exception is made for MADV_DONTNEED on anonymous mappings,
+-       that applications may rely on to zero out pages. */
+-    if (advice & MADV_DONTNEED) {
+-        end = start + len;
+-        for (addr = start; addr < end; addr += TARGET_PAGE_SIZE) {
+-            if (page_get_flags(addr) & PAGE_MAP_ANONYMOUS) {
+-                ret = madvise(g2h(addr), TARGET_PAGE_SIZE, MADV_DONTNEED);
+-                if (ret != 0) {
+-                    return ret;
+-                }
+-            }
+-        }
++    /*
++     * A straight passthrough may not be safe because qemu sometimes turns
++     * private file-backed mappings into anonymous mappings.
++     *
++     * This is a hint, so ignoring and returning success is ok.
++     *
++     * This breaks MADV_DONTNEED, completely implementing which is quite
++     * complicated. However, there is one low-hanging fruit: host-page-aligned
++     * anonymous mappings. In this case passthrough is safe, so do it.
++     */
++    mmap_lock();
++    if ((advice & MADV_DONTNEED) &&
++        can_passthrough_madv_dontneed(start, end)) {
++        ret = madvise(g2h(start), len, MADV_DONTNEED);
+     }
+-    return 0;
++    mmap_unlock();
++
++    return ret;
+ }
+\ No newline at end of file
+diff --git a/linux-user/qemu.h b/linux-user/qemu.h
+index 2df9da3..0021c38 100644
+--- a/linux-user/qemu.h
++++ b/linux-user/qemu.h
+@@ -440,7 +440,7 @@ int target_munmap(abi_ulong start, abi_ulong len);
+ abi_long target_mremap(abi_ulong old_addr, abi_ulong old_size,
+                        abi_ulong new_size, unsigned long flags,
+                        abi_ulong new_addr);
+-int target_madvise(abi_ulong start, abi_ulong len, int advice);
++abi_long target_madvise(abi_ulong start, abi_ulong len_in, int advice);
+ extern unsigned long last_brk;
+ extern abi_ulong mmap_next_start;
+ abi_ulong mmap_find_vma(abi_ulong, abi_ulong, abi_ulong);
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 7a084db..a184e5c 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -4319,8 +4319,7 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
+ 
+     page_set_flags(raddr, raddr + shm_info.shm_segsz,
+                    PAGE_VALID | PAGE_READ |
+-                   ((shmflg & SHM_RDONLY) ? 0 : PAGE_WRITE),
+-                   PAGE_SET_ALL_FLAGS);
++                   ((shmflg & SHM_RDONLY)? 0 : PAGE_WRITE));
+ 
+     for (i = 0; i < N_SHM_REGIONS; i++) {
+         if (!shm_regions[i].in_use) {
+@@ -4346,8 +4345,7 @@ static inline abi_long do_shmdt(abi_ulong shmaddr)
+     for (i = 0; i < N_SHM_REGIONS; ++i) {
+         if (shm_regions[i].in_use && shm_regions[i].start == shmaddr) {
+             shm_regions[i].in_use = false;
+-            page_set_flags(shmaddr, shmaddr + shm_regions[i].size, 0,
+-                           PAGE_SET_ALL_FLAGS);
++            page_set_flags(shmaddr, shmaddr + shm_regions[i].size, 0);
+             break;
+         }
+     }
+@@ -11568,6 +11566,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+ 
+ #ifdef TARGET_NR_madvise
+     case TARGET_NR_madvise:
++        /* A straight passthrough may not be safe because qemu sometimes
++           turns private file-backed mappings into anonymous mappings.
++           This will break MADV_DONTNEED.
++           This is a hint, so ignoring and returning success is ok.  */
+         return get_errno(target_madvise(arg1, arg2, arg3));
+ #endif
+ #ifdef TARGET_NR_fcntl64
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/0026-Fallback-to-copy-when-NR_linkat-failed.patch
+++ b/build-hnp/qemu-vroot/0026-Fallback-to-copy-when-NR_linkat-failed.patch
@@ -1,0 +1,73 @@
+From c8f11d19daf267c73a589939868e32f46fb8745c Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sat, 19 Jul 2025 11:46:19 +0800
+Subject: [PATCH 26/27] Fallback to copy when NR_linkat failed
+
+---
+ linux-user/syscall.c | 43 +++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 39 insertions(+), 4 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index a184e5c..6898484 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -7914,8 +7914,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+             p2 = lock_user_string(arg2);
+             if (!p || !p2)
+                 ret = -TARGET_EFAULT;
+-            else
+-                ret = get_errno(link(p, p2));
++            else {
++                char reloc1[PATH_MAX];
++                char reloc2[PATH_MAX];
++                ret = get_errno(link(relocate_path_at(AT_FDCWD, p, reloc1, false),
++                    relocate_path_at(AT_FDCWD, p2, reloc2, false)));
++            }
+             unlock_user(p2, arg2, 0);
+             unlock_user(p, arg1, 0);
+         }
+@@ -7931,8 +7935,39 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+             p2 = lock_user_string(arg4);
+             if (!p || !p2)
+                 ret = -TARGET_EFAULT;
+-            else
+-                ret = get_errno(linkat(arg1, p, arg3, p2, arg5));
++            else {
++                char reloc1[PATH_MAX];
++                relocate_path_at(arg1, p, reloc1, false);
++                char reloc2[PATH_MAX];
++                relocate_path_at(arg3, p2, reloc2, false);
++                ret = get_errno(linkat(arg1, reloc1, arg3, reloc2, arg5));
++                if (ret < 0 && errno == EACCES) {
++                    //  replace linkat by copy
++                    int from_fd = openat(arg1, reloc1, O_RDONLY | O_LARGEFILE);
++                    if (from_fd < 0) {
++                        goto linkat_end;
++                    }
++
++                    struct stat s;
++                    if (fstat(from_fd, &s) < 0 || !S_ISREG(s.st_mode)) {
++                        errno = ENOENT;
++                        goto linkat_end;
++                    }
++                    int to_fd = creat(reloc2, s.st_mode);
++                    if (to_fd < 0) {
++                        goto linkat_end;
++                    }
++
++                    char buf[4096];
++                    int rd;
++                    while ((rd = read(from_fd, buf, sizeof(buf))) > 0) {
++                        write(to_fd, buf, rd);
++                    }
++                    ret = 0;
++                    errno = 0;
++                }
++            }
++        linkat_end:
+             unlock_user(p, arg2, 0);
+             unlock_user(p2, arg4, 0);
+         }
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/0027-Disable-setfsuid-setfsgid-on-OHOS.patch
+++ b/build-hnp/qemu-vroot/0027-Disable-setfsuid-setfsgid-on-OHOS.patch
@@ -1,0 +1,32 @@
+From 0fb1c4cb9e206e66d7fac9652203ed89b4a320ac Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sat, 19 Jul 2025 16:49:09 +0800
+Subject: [PATCH 27/27] Disable setfsuid/setfsgid on OHOS
+
+---
+ linux-user/syscall.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 6898484..3d6c25b 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -11184,9 +11184,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+         // return get_errno(sys_setgid(low2highgid(arg1)));
+         return 0;
+     case TARGET_NR_setfsuid:
+-        return get_errno(setfsuid(arg1));
++        // we cannot use on OHOS
++        // return get_errno(setfsuid(arg1));
++        return 0;
+     case TARGET_NR_setfsgid:
+-        return get_errno(setfsgid(arg1));
++        // we cannot use on OHOS
++        // return get_errno(setfsgid(arg1));
++        return 0;
+ 
+ #ifdef TARGET_NR_lchown32
+     case TARGET_NR_lchown32:
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -27,6 +27,9 @@ all: download/qemu-5.0
 	cd temp/qemu-5.0 && git apply ../../0022-Replace-renameat-on-symlink-by-symlinkat-and-unlinka.patch
 	cd temp/qemu-5.0 && git apply ../../0023-Fix-flags-about-symlink-for-NR_statx.patch
 	cd temp/qemu-5.0 && git apply ../../0024-Complete-tcg_qemu_tb_exec-for-unimplemented-TCGOpcod.patch
+	cd temp/qemu-5.0 && git apply ../../0025-Fix-target-madvise.patch
+	cd temp/qemu-5.0 && git apply ../../0026-Fallback-to-copy-when-linkat-failed.patch
+	cd temp/qemu-5.0 && git apply ../../0027-Disable-setfsuid-setfsgid-on-OHOS.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -26,6 +26,7 @@ all: download/qemu-5.0
 	cd temp/qemu-5.0 && git apply ../../0021-Fix-path-relocation-for-NR_statx.patch
 	cd temp/qemu-5.0 && git apply ../../0022-Replace-renameat-on-symlink-by-symlinkat-and-unlinka.patch
 	cd temp/qemu-5.0 && git apply ../../0023-Fix-flags-about-symlink-for-NR_statx.patch
+	cd temp/qemu-5.0 && git apply ../../0024-Complete-tcg_qemu_tb_exec-for-unimplemented-TCGOpcod.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \


### PR DESCRIPTION
Fix some errors to enable gcc:
* some unimplemented TCGOpcodes
* unknown issue of madvise(MADV_DONTNEED) causes `as` crash
* copy file when linkat failed with EACCES
* disable setfsuid/setfsgid

Now gcc can be installed and run in `qemu-vroot` to compile a `Hello World`
![3b3a5db4dd8f0d08a4a62d3d96c17631](https://github.com/user-attachments/assets/f63f3253-acc7-47cf-9abb-4f47c0e59b9f)
