### PR TITLE
fix: terminal CSI Pm_m blink issue

### DIFF
--- a/entry/src/main/cpp/terminal.cpp
+++ b/entry/src/main/cpp/terminal.cpp
@@ -113,6 +113,265 @@ term_style::term_style() {
     bg_blue = predefined_colors[white][2] / 255.0;
 }
 
+uint32_t color_map_256[] = {
+    0x000000,
+    0x800000,
+    0x008000,
+    0x808000,
+    0x000080,
+    0x800080,
+    0x008080,
+    0xc0c0c0,
+    0x808080,
+    0xff0000,
+    0x00ff00, 
+    0xffff00, 
+    0x0000ff,
+    0xff00ff,
+    0x00ffff,
+    0xffffff,
+    0x000000,
+    0x00005f,
+    0x000087,
+    0x0000af,
+    0x0000d7,
+    0x0000ff,
+    0x005f00,
+    0x005f5f,
+    0x005f87,
+    0x005faf,
+    0x005fd7,
+    0x005fff,
+    0x008700,
+    0x00875f,
+    0x008787,
+    0x0087af,
+    0x0087d7,
+    0x0087ff,
+    0x00af00,
+    0x00af5f,
+    0x00af87,
+    0x00afaf,
+    0x00afd7,
+    0x00afff,
+    0x00d700,
+    0x00d75f,
+    0x00d787,
+    0x00d7af,
+    0x00d7d7,
+    0x00d7ff,
+    0x00ff00,
+    0x00ff5f,
+    0x00ff87,
+    0x00ffaf,
+    0x00ffd7,
+    0x00ffff,
+    0x5f0000,
+    0x5f005f,
+    0x5f0087,
+    0x5f00af,
+    0x5f00d7,
+    0x5f00ff,
+    0x5f5f00,
+    0x5f5f5f,
+    0x5f5f87,
+    0x5f5faf,
+    0x5f5fd7,
+    0x5f5fff,
+    0x5f8700,
+    0x5f875f,
+    0x5f8787,
+    0x5f87af,
+    0x5f87d7,
+    0x5f87ff,
+    0x5faf00,
+    0x5faf5f,
+    0x5faf87,
+    0x5fafaf,
+    0x5fafd7,
+    0x5fafff,
+    0x5fd700,
+    0x5fd75f,
+    0x5fd787,
+    0x5fd7af,
+    0x5fd7d7,
+    0x5fd7ff,
+    0x5fff00,
+    0x5fff5f,
+    0x5fff87,
+    0x5fffaf,
+    0x5fffd7,
+    0x5fffff,
+    0x870000,
+    0x87005f,
+    0x870087,
+    0x8700af,
+    0x8700d7,
+    0x8700ff,
+    0x875f00,
+    0x875f5f,
+    0x875f87,
+    0x875faf,
+    0x875fd7,
+    0x875fff,
+    0x878700, 
+    0x87875f, 
+    0x878787, 
+    0x8787af, 
+    0x8787d7, 
+    0x8787ff,
+    0x87af00, 
+    0x87af5f, 
+    0x87af87, 
+    0x87afaf, 
+    0x87afd7, 
+    0x87afff,
+    0x87d700, 
+    0x87d75f, 
+    0x87d787, 
+    0x87d7af, 
+    0x87d7d7, 
+    0x87d7ff,
+    0x87ff00, 
+    0x87ff5f, 
+    0x87ff87, 
+    0x87ffaf, 
+    0x87ffd7, 
+    0x87ffff,
+    0xaf0000, 
+    0xaf005f, 
+    0xaf0087, 
+    0xaf00af, 
+    0xaf00d7, 
+    0xaf00ff,
+    0xaf5f00, 
+    0xaf5f5f, 
+    0xaf5f87, 
+    0xaf5faf, 
+    0xaf5fd7, 
+    0xaf5fff,
+    0xaf8700, 
+    0xaf875f, 
+    0xaf8787, 
+    0xaf87af, 
+    0xaf87d7, 
+    0xaf87ff,
+    0xafaf00, 
+    0xafaf5f, 
+    0xafaf87, 
+    0xafafaf, 
+    0xafafd7, 
+    0xafafff,
+    0xafd700, 
+    0xafd75f, 
+    0xafd787, 
+    0xafd7af, 
+    0xafd7d7, 
+    0xafd7ff,
+    0xafff00, 
+    0xafff5f, 
+    0xafff87, 
+    0xafffaf, 
+    0xafffd7, 
+    0xafffff,
+    0xd70000, 
+    0xd7005f, 
+    0xd70087, 
+    0xd700af, 
+    0xd700d7, 
+    0xd700ff,
+    0xd75f00, 
+    0xd75f5f, 
+    0xd75f87, 
+    0xd75faf, 
+    0xd75fd7, 
+    0xd75fff,
+    0xd78700, 
+    0xd7875f, 
+    0xd78787, 
+    0xd787af, 
+    0xd787d7, 
+    0xd787ff,
+    0xd7af00, 
+    0xd7af5f, 
+    0xd7af87, 
+    0xd7afaf, 
+    0xd7afd7, 
+    0xd7afff,
+    0xd7d700, 
+    0xd7d75f, 
+    0xd7d787, 
+    0xd7d7af, 
+    0xd7d7d7, 
+    0xd7d7ff,
+    0xd7ff00, 
+    0xd7ff5f, 
+    0xd7ff87, 
+    0xd7ffaf, 
+    0xd7ffd7, 
+    0xd7ffff,
+    0xff0000, 
+    0xff005f, 
+    0xff0087, 
+    0xff00af, 
+    0xff00d7, 
+    0xff00ff,
+    0xff5f00, 
+    0xff5f5f, 
+    0xff5f87, 
+    0xff5faf, 
+    0xff5fd7, 
+    0xff5fff,
+    0xff8700, 
+    0xff875f, 
+    0xff8787, 
+    0xff87af, 
+    0xff87d7, 
+    0xff87ff,
+    0xffaf00, 
+    0xffaf5f, 
+    0xffaf87, 
+    0xffafaf, 
+    0xffafd7, 
+    0xffafff,
+    0xffd700, 
+    0xffd75f, 
+    0xffd787, 
+    0xffd7af, 
+    0xffd7d7, 
+    0xffd7ff,
+    0xffff00, 
+    0xffff5f, 
+    0xffff87, 
+    0xffffaf, 
+    0xffffd7, 
+    0xffffff,
+    0x080808, 
+    0x121212, 
+    0x1c1c1c, 
+    0x262626, 
+    0x303030, 
+    0x3a3a3a,
+    0x444444, 
+    0x4e4e4e, 
+    0x585858, 
+    0x606060, 
+    0x666666, 
+    0x767676,
+    0x808080, 
+    0x8a8a8a, 
+    0x949494, 
+    0x9e9e9e, 
+    0xa8a8a8, 
+    0xb2b2b2,
+    0xbcbcbc, 
+    0xc6c6c6, 
+    0xd0d0d0, 
+    0xdadada, 
+    0xe4e4e4, 
+    0xeeeeee
+};
+
 static std::vector<std::string> SplitString(const std::string &str, const std::string &delimiter) {
     std::vector<std::string> result;
     size_t start = 0;
@@ -147,6 +406,11 @@ static int baseline_height = 10;
 static float scroll_offset = 0;
 
 const int MAX_HISTORY_LINES = 5000;
+
+constexpr uint32_t TrueColorFrom(uint8_t index) {
+    return color_map_256[index];
+}
+
 void terminal_context::ResizeTo(int new_term_row, int new_term_col) {
     int old_term_col = term_col;
     term_row = new_term_row;
@@ -648,8 +912,9 @@ void terminal_context::HandleCSI(uint8_t current) {
 
             // set color
             std::vector<std::string> parts = SplitString(escape_buffer, ";");
-            for (auto part : parts) {
+            for (size_t i = 0; i < parts.size(); i++) {
                 int param = 0;
+                std::string part = parts[i];
                 sscanf(part.c_str(), "%d", &param);
                 if (param == 0) {
                     // reset all attributes to their defaults
@@ -663,7 +928,7 @@ void terminal_context::HandleCSI(uint8_t current) {
                 } else if (param == 4) {
                     // set underline, CSI 4 m
                     // TODO
-                } else if (param == 5) {
+                } else if (param == 5 || param == 6) {
                     // set blink, CSI 5 m
                     current_style.blink = true;
                 } else if (param == 7) {
@@ -680,12 +945,20 @@ void terminal_context::HandleCSI(uint8_t current) {
                 } else if (param == 21) {
                     // set doubly underlined, CSI 21 m
                     // TODO
+                } else if (param == 22) {
+                    // set not bold faint, CSI 22 m
+                    current_style.weight = font_weight::regular;
                 } else if (param == 24) {
                     // set not underlined, CSI 24 m
                     // TODO
+                } else if (param == 25) {
+                    // set steady, CSI 25 m
+                    current_style.blink = false;
                 } else if (param == 27) {
                     // positive (not inverse), CSI 27 m
-                    // TODO
+                    std::swap(current_style.fg_red, current_style.bg_red);
+                    std::swap(current_style.fg_green, current_style.bg_green);
+                    std::swap(current_style.fg_blue, current_style.bg_blue);
                 } else if (param == 30) {
                     // black foreground
                     current_style.fg_red = predefined_colors[black][0] / 255.0;
@@ -726,9 +999,38 @@ void terminal_context::HandleCSI(uint8_t current) {
                     current_style.fg_red = predefined_colors[white][0] / 255.0;
                     current_style.fg_green = predefined_colors[white][1] / 255.0;
                     current_style.fg_blue = predefined_colors[white][2] / 255.0;
-                } else if (param == 38) {
+                } else if (param == 38 || param == 48) {
                     // foreground color: extended color, CSI 38 : ... m
-                    // TODO
+                    if (parts.size() > 1) {
+                        int color_type = std::stoi(parts[++i]);
+                        if (color_type == 5 && parts.size() > 2) { // 256-color mode
+                            int color_index = std::stoi(parts[++i]);
+                            uint32_t color = TrueColorFrom(color_index);
+                            if (param == 38) {
+                                current_style.fg_red = ((color >> 16) & 0xff) / 255.0;
+                                current_style.fg_green = ((color >> 8) & 0xff)  / 255.0;
+                                current_style.fg_blue = ((color >> 0) & 0xff)  / 255.0;
+                            } else {
+                                current_style.bg_red = ((color >> 16) & 0xff) / 255.0;
+                                current_style.bg_green = ((color >> 8) & 0xff) / 255.0;
+                                current_style.bg_blue = ((color >> 0) & 0xff) / 255.0;
+                            }
+                        }
+                        else if (color_type == 2 && parts.size() > 4) { // RGB mode
+                            int r = std::stoi(parts[++i]);
+                            int g = std::stoi(parts[++i]);
+                            int b = std::stoi(parts[++i]);
+                            if (param == 38) {
+                                current_style.fg_red = r / 255.0;
+                                current_style.fg_green = g / 255.0;
+                                current_style.fg_blue = b / 255.0;
+                            } else {
+                                current_style.bg_red = r / 255.0;
+                                current_style.bg_green = g / 255.0;
+                                current_style.bg_blue = b / 255.0;
+                            }
+                        }
+                    }
                 } else if (param == 39) {
                     // default foreground
                     current_style.fg_red = predefined_colors[black][0] / 255.0;
@@ -774,9 +1076,6 @@ void terminal_context::HandleCSI(uint8_t current) {
                     current_style.bg_red = predefined_colors[white][0] / 255.0;
                     current_style.bg_green = predefined_colors[white][1] / 255.0;
                     current_style.bg_blue = predefined_colors[white][2] / 255.0;
-                } else if (param == 48) {
-                    // background color: extended color, CSI 48 : ... m
-                    // TODO
                 } else if (param == 49) {
                     // default background
                     current_style.bg_red = predefined_colors[white][0] / 255.0;
@@ -787,6 +1086,81 @@ void terminal_context::HandleCSI(uint8_t current) {
                     current_style.fg_red = predefined_colors[brblack][0] / 255.0;
                     current_style.fg_green = predefined_colors[brblack][1] / 255.0;
                     current_style.fg_blue = predefined_colors[brblack][2] / 255.0;
+                } else if (param == 91) {
+                    // red foreground
+                    current_style.fg_red = predefined_colors[brred][0] / 255.0;
+                    current_style.fg_green = predefined_colors[brred][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[brred][2] / 255.0;
+                } else if (param == 92) {
+                    // green foreground
+                    current_style.fg_red = predefined_colors[brgreen][0] / 255.0;
+                    current_style.fg_green = predefined_colors[brgreen][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[brgreen][2] / 255.0;
+                } else if (param == 93) {
+                    // yellow foreground
+                    current_style.fg_red = predefined_colors[bryellow][0] / 255.0;
+                    current_style.fg_green = predefined_colors[bryellow][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[bryellow][2] / 255.0;
+                } else if (param == 94) {
+                    // blue foreground
+                    current_style.fg_red = predefined_colors[brblue][0] / 255.0;
+                    current_style.fg_green = predefined_colors[brblue][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[brblue][2] / 255.0;
+                } else if (param == 95) {
+                    // magenta foreground
+                    current_style.fg_red = predefined_colors[brmagenta][0] / 255.0;
+                    current_style.fg_green = predefined_colors[brmagenta][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[brmagenta][2] / 255.0;
+                } else if (param == 96) {
+                    // cyan foreground
+                    current_style.fg_red = predefined_colors[brcyan][0] / 255.0;
+                    current_style.fg_green = predefined_colors[brcyan][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[brcyan][2] / 255.0;
+                } else if (param == 97) {
+                    // white foreground
+                    current_style.fg_red = predefined_colors[brwhite][0] / 255.0;
+                    current_style.fg_green = predefined_colors[brwhite][1] / 255.0;
+                    current_style.fg_blue = predefined_colors[brwhite][2] / 255.0;
+                } else if (param == 100) {
+                    // black background
+                    current_style.bg_red = predefined_colors[brblack][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brblack][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brblack][2] / 255.0;
+                } else if (param == 101) {
+                    // red background
+                    current_style.bg_red = predefined_colors[brred][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brred][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brred][2] / 255.0;
+                } else if (param == 102) {
+                    // green background
+                    current_style.bg_red = predefined_colors[brgreen][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brgreen][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brgreen][2] / 255.0;
+                } else if (param == 103) {
+                    // yellow background
+                    current_style.bg_red = predefined_colors[bryellow][0] / 255.0;
+                    current_style.bg_green = predefined_colors[bryellow][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[bryellow][2] / 255.0;
+                } else if (param == 104) {
+                    // blue background
+                    current_style.bg_red = predefined_colors[brblue][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brblue][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brblue][2] / 255.0;
+                } else if (param == 105) {
+                    // magenta background
+                    current_style.bg_red = predefined_colors[brmagenta][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brmagenta][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brmagenta][2] / 255.0;
+                } else if (param == 106) {
+                    // cyan background
+                    current_style.bg_red = predefined_colors[brcyan][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brcyan][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brcyan][2] / 255.0;
+                } else if (param == 107) {
+                    // white background
+                    current_style.bg_red = predefined_colors[brwhite][0] / 255.0;
+                    current_style.bg_green = predefined_colors[brwhite][1] / 255.0;
+                    current_style.bg_blue = predefined_colors[brwhite][2] / 255.0;
                 } else {
                     OH_LOG_WARN(LOG_APP, "Unknown CSI Pm m: %{public}s from %{public}s %{public}c",
                                 part.c_str(), escape_buffer.c_str(), current);
@@ -795,7 +1169,12 @@ void terminal_context::HandleCSI(uint8_t current) {
         } else if (current == 'm' && escape_buffer.size() > 0 && escape_buffer[0] == '>') {
             // CSI > Pp m, XTMODKEYS, set/reset key modifier options
             // TODO
-        } else if (current == 'n' && escape_buffer == "6") {
+        } else if (current == 'n' && escape_buffer == "5") {
+            // CSI 5 n - Device Status Report
+            // send "OK" - ESC [ 0 n
+            uint8_t ok_response[] = {0x1B, '[', '0', 'n'};
+            WriteFull(ok_response, sizeof(ok_response));
+        } else if (current == 'n' && (escape_buffer == "6")) {
             // CSI Ps n, DSR, Device Status Report
             // Ps = 6: Report Cursor Position (CPR)
             // send ESC [ row ; col R


### PR DESCRIPTION
The previous implementation incorrectly parsed the parameters carried when the terminal received P s = 38/48. For example, upon receiving P s = 3 8 ; 5 ; P s, it would mistakenly interpret the middle 5 as a blink command. This patch fixes the issue while adding support for 16-bit colors (with bright variants), 256-color, and truecolor.