### PR TITLE
fix #45: frexpl() is missing or broken when cross building on ARM64 Linux host

### DIFF
--- a/build-hnp/glib/Makefile
+++ b/build-hnp/glib/Makefile
@@ -16,6 +16,8 @@ all: download/glib
 	cd temp/glib && echo "cpu_family = 'aarch64'" >> cross.txt
 	cd temp/glib && echo "cpu = 'aarch64'" >> cross.txt
 	cd temp/glib && echo "endian = 'little'" >> cross.txt
+	cd temp/glib && echo "[properties]" >> cross.txt
+	cd temp/glib && echo "needs_exe_wrapper = true" >> cross.txt
 	cd temp/glib && PKG_CONFIG=$(shell which pkg-config) PKG_CONFIG_LIBDIR=$(shell pwd)/../sysroot/lib/pkgconfig meson --cross-file cross.txt --prefix=/data/app/base.org/base_1.0 -Dselinux=false -Dinstalled_tests=false -Ddtrace=disabled -Dsystemtap=disabled -Dselinux=disabled -Dlibelf=disabled -Dlibmount=disabled -Ddefault_library=both -Dsysprof=disabled build
 	cd temp/glib/build && meson compile
 	mkdir -p ../sysroot


### PR DESCRIPTION
meson 的 Bug https://github.com/mesonbuild/meson/issues/6594 导致了 https://github.com/TermonyHQ/Termony/issues/45

问题在于 meson 编译 `build-hnp/glib/temp/glib/build/meson-private/sanitycheckc.exe` 的时候链接的是 Debian 12 的 gnu libc 库，于是误以为交叉编译出来的程序在 host 里可以执行。

等到检测`frexpl()`是否存在的时候，由于测试程序链接到了 musl 库，没办法在 Debian 12 里执行，导致 meson 误以为 `frexpl()` 不存在。

根据 https://github.com/mesonbuild/meson/issues/6594 ，只要在 cross.txt 里添加以下内容即可解决问题：

```
[properties]
needs_exe_wrapper = true
```

亲测有效，现在 Debian 12 ARM64 里 glib 和 qemu 都能编过去了。

对 x64 和 macOS 编译应该都没有副作用，因为这些平台的 sanitycheckc 测试本来就是失败的，加上 needs_exe_wrapper 不改变结果。