### PR TITLE
Enable jit of qemu

### DIFF
--- a/build-hnp/qemu-vroot/0033-Enable-jit.patch
+++ b/build-hnp/qemu-vroot/0033-Enable-jit.patch
@@ -1,0 +1,62 @@
+From fb8023ef92614c0016cb57902bc51c642cf7c1d8 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Tue, 29 Jul 2025 09:17:37 +0800
+Subject: [PATCH 33/33] Enable jit
+
+---
+ accel/tcg/translate-all.c | 16 +++++++++++++++-
+ include/qemu/osdep.h      |  5 +++++
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index 45b1918..3628604 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -1041,13 +1041,27 @@ static inline void *alloc_code_gen_buffer(void)
+ #else
+ static inline void *alloc_code_gen_buffer(void)
+ {
+-    // avoid PROT_EXEC on OHOS
++#if !defined(CONFIG_TCG_INTERPRETER)
++    int prot = PROT_WRITE | PROT_READ | PROT_EXEC;
++#else
+     int prot = PROT_WRITE | PROT_READ;
++#endif
+     int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+     size_t size = tcg_ctx->code_gen_buffer_size;
+     void *buf;
+ 
++#if !defined(CONFIG_TCG_INTERPRETER)
++    //  required by OHOS
++    prctl(PRCTL_SET_JITFORT, 0, 0);
++#endif
++
+     buf = mmap(NULL, size, prot, flags, -1, 0);
++
++#if !defined(CONFIG_TCG_INTERPRETER)
++    //  required by OHOS
++    prctl(PRCTL_SET_JITFORT, 0, 1);
++#endif
++
+     if (buf == MAP_FAILED) {
+         return NULL;
+     }
+diff --git a/include/qemu/osdep.h b/include/qemu/osdep.h
+index 1866cab..077a272 100644
+--- a/include/qemu/osdep.h
++++ b/include/qemu/osdep.h
+@@ -115,6 +115,11 @@ extern int daemon(int, int);
+ #define WEXITSTATUS(x) (x)
+ #endif
+ 
++#if !defined(CONFIG_TCG_INTERPRETER)
++#include <sys/prctl.h>
++#define PRCTL_SET_JITFORT   0x6a6974
++#endif
++
+ #ifdef _WIN32
+ #include "sysemu/os-win32.h"
+ #endif
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -34,13 +34,14 @@ all: download/qemu-5.0
 	cd temp/qemu-5.0 && git apply ../../0030-Reuse-passwd-file-of-host.patch
 	cd temp/qemu-5.0 && git apply ../../0031-Restore-path-from-syscall-to-users.patch
 	cd temp/qemu-5.0 && git apply ../../0032-Reuse-sys-of-host.patch
+	cd temp/qemu-5.0 && git apply ../../0033-Enable-jit.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \
 	PKG_CONFIG_LIBDIR=$(shell pwd)/../sysroot/lib/pkgconfig:$(shell pwd)/../sysroot/share/pkgconfig \
 	PKG_CONFIG_SYSROOT_DIR=$(shell pwd)/../sysroot \
 	CFLAGS="-D_UAPI_LINUX_VIRTIO_VSOCK_H -D_UAPI_LINUX_VIRTIO_TYPES_H -D_UAPI_LINUX_VIRTIO_RING_H -D_UAPI_LINUX_VIRTIO_PMEM_H -D_UAPI_LINUX_VIRTIO_NET_H -D_UAPI_LINUX_VIRTIO_IOMMU_H -D_UAPI_LINUX_VIRTIO_FS_H -D_UAPI_LINUX_VIRTIO_CONSOLE_H -D_UAPI_LINUX_VIRTIO_CONFIG_H -D_LINUX_SYSINFO_H -D__user= -D__force= ${CFLAGS} -I$(shell pwd)/../sysroot/include/glib-2.0 -I$(shell pwd)/../sysroot/lib/glib-2.0/include -L$(shell pwd)/../sysroot/lib" \
-	./configure --target-list=aarch64-linux-user,x86_64-linux-user --cross-prefix= --host-cc=cc --disable-kvm --disable-xen --disable-docs --disable-system --enable-tcg-interpreter --disable-werror --static \
+	./configure --target-list=aarch64-linux-user,x86_64-linux-user --cross-prefix= --host-cc=cc --disable-kvm --disable-xen --disable-docs --disable-system --disable-werror --static \
 	 --disable-bsd-user --disable-guest-agent --disable-strip --disable-gcrypt --disable-debug-info --disable-debug-tcg --enable-attr --disable-brlapi --disable-linux-aio --disable-bzip2 --disable-cap-ng --disable-curl --disable-fdt --disable-glusterfs --disable-gnutls --disable-nettle --disable-gtk --disable-rdma --disable-libiscsi --disable-vnc-jpeg --disable-kvm --disable-lzo --disable-curses --disable-libnfs --disable-numa --disable-opengl --disable-vnc-png --disable-rbd --disable-vnc-sasl --disable-sdl --disable-seccomp --disable-smartcard --disable-snappy --disable-spice --disable-libusb --disable-usb-redir --disable-vde --disable-vhost-net --disable-virglrenderer --disable-virtfs --disable-vnc --disable-vte --disable-xen --disable-xen-pci-passthrough --disable-xfsctl --enable-linux-user --disable-blobs --disable-tools
 	cd temp/qemu-5.0 && make -j $(shell nproc)
 	cp temp/qemu-5.0/aarch64-linux-user/qemu-aarch64 ./build/bin/

--- a/build-hnp/qemu/0001-Initial-porting-to-OHOS.patch
+++ b/build-hnp/qemu/0001-Initial-porting-to-OHOS.patch
@@ -1,30 +1,37 @@
-diff --git a/.gitignore b/.gitignore
-index 0c5af83..c175888 100644
---- a/.gitignore
-+++ b/.gitignore
-@@ -161,3 +161,4 @@ trace-dtrace-root.dtrace
- trace-ust-all.h
- trace-ust-all.c
- /target/arm/decode-sve.inc.c
-+build
+From bb4ec5afac1b27b534bf0bf2010bc4cbdeda461f Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sun, 6 Jul 2025 01:36:32 +0800
+Subject: [PATCH 1/5] Initial porting to OHOS
+
+---
+ accel/tcg/translate-all.c         |  3 ++-
+ linux-user/aarch64/syscall_nr.h   | 13 +++++++------
+ linux-user/elfload.c              | 12 +++++++++---
+ linux-user/host/aarch64/hostdep.h |  4 +++-
+ linux-user/linuxload.c            |  7 ++++---
+ linux-user/signal.c               | 16 ++++++++++------
+ linux-user/syscall.c              | 11 ++++++-----
+ 7 files changed, 41 insertions(+), 25 deletions(-)
+
 diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
-index 9924e66..b0d1ec7 100644
+index 9924e66..45b1918 100644
 --- a/accel/tcg/translate-all.c
 +++ b/accel/tcg/translate-all.c
-@@ -1041,7 +1041,7 @@ static inline void *alloc_code_gen_buffer(void)
+@@ -1041,7 +1041,8 @@ static inline void *alloc_code_gen_buffer(void)
  #else
  static inline void *alloc_code_gen_buffer(void)
  {
 -    int prot = PROT_WRITE | PROT_READ | PROT_EXEC;
++    // avoid PROT_EXEC on OHOS
 +    int prot = PROT_WRITE | PROT_READ;
      int flags = MAP_PRIVATE | MAP_ANONYMOUS;
      size_t size = tcg_ctx->code_gen_buffer_size;
      void *buf;
 diff --git a/linux-user/aarch64/syscall_nr.h b/linux-user/aarch64/syscall_nr.h
-index 85de000..def6a25 100644
+index 85de000..32486ac 100644
 --- a/linux-user/aarch64/syscall_nr.h
 +++ b/linux-user/aarch64/syscall_nr.h
-@@ -186,12 +186,6 @@
+@@ -186,12 +186,13 @@
  #define TARGET_NR_getegid 177
  #define TARGET_NR_gettid 178
  #define TARGET_NR_sysinfo 179
@@ -34,111 +41,145 @@ index 85de000..def6a25 100644
 -#define TARGET_NR_mq_timedreceive 183
 -#define TARGET_NR_mq_notify 184
 -#define TARGET_NR_mq_getsetattr 185
++// unavailable on OHOS
++// #define TARGET_NR_mq_open 180
++// #define TARGET_NR_mq_unlink 181
++// #define TARGET_NR_mq_timedsend 182
++// #define TARGET_NR_mq_timedreceive 183
++// #define TARGET_NR_mq_notify 184
++// #define TARGET_NR_mq_getsetattr 185
  #define TARGET_NR_msgget 186
  #define TARGET_NR_msgctl 187
  #define TARGET_NR_msgrcv 188
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 619c054..558df4d 100644
+index 619c054..dea50b1 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
-@@ -2464,7 +2464,6 @@ static void load_elf_image(const char *image_name, int image_fd,
+@@ -2464,7 +2464,8 @@ static void load_elf_image(const char *image_name, int image_fd,
  
              if (eppnt->p_flags & PF_R) elf_prot =  PROT_READ;
              if (eppnt->p_flags & PF_W) elf_prot |= PROT_WRITE;
 -            if (eppnt->p_flags & PF_X) elf_prot |= PROT_EXEC;
++            // avoid PROT_EXEC on OHOS
++            // if (eppnt->p_flags & PF_X) elf_prot |= PROT_EXEC;
  
              vaddr = load_bias + eppnt->p_vaddr;
              vaddr_po = TARGET_ELF_PAGEOFFSET(vaddr);
-@@ -2495,7 +2494,7 @@ static void load_elf_image(const char *image_name, int image_fd,
+@@ -2495,7 +2496,10 @@ static void load_elf_image(const char *image_name, int image_fd,
              }
  
              /* Find the full program boundaries.  */
 -            if (elf_prot & PROT_EXEC) {
++            // we removed PROT_EXEC from elf_prot,
++            // check p_flags instead
++            // if (elf_prot & PROT_EXEC) {
 +            if (eppnt->p_flags & PF_X) {
                  if (vaddr < info->start_code) {
                      info->start_code = vaddr;
                  }
-@@ -2874,7 +2873,7 @@ int load_elf_binary(struct linux_binprm *bprm, struct image_info *info)
+@@ -2874,7 +2878,9 @@ int load_elf_binary(struct linux_binprm *bprm, struct image_info *info)
                 and some applications "depend" upon this behavior.  Since
                 we do not have the power to recompile these, we emulate
                 the SVr4 behavior.  Sigh.  */
 -            target_mmap(0, qemu_host_page_size, PROT_READ | PROT_EXEC,
++            // avoid PROT_EXEC on OHOS
++            // target_mmap(0, qemu_host_page_size, PROT_READ | PROT_EXEC,
 +            target_mmap(0, qemu_host_page_size, PROT_READ,
                          MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
          }
  #ifdef TARGET_MIPS
 diff --git a/linux-user/host/aarch64/hostdep.h b/linux-user/host/aarch64/hostdep.h
-index a8d41a2..34d934f 100644
+index a8d41a2..cc35d13 100644
 --- a/linux-user/host/aarch64/hostdep.h
 +++ b/linux-user/host/aarch64/hostdep.h
-@@ -25,7 +25,7 @@ extern char safe_syscall_end[];
+@@ -25,7 +25,9 @@ extern char safe_syscall_end[];
  static inline void rewind_if_in_safe_syscall(void *puc)
  {
      ucontext_t *uc = puc;
 -    __u64 *pcreg = &uc->uc_mcontext.pc;
++    // missing __u64 on OHOS
++    // __u64 *pcreg = &uc->uc_mcontext.pc;
 +    uint64_t *pcreg = &uc->uc_mcontext.pc;
  
      if (*pcreg > (uintptr_t)safe_syscall_start
          && *pcreg < (uintptr_t)safe_syscall_end) {
 diff --git a/linux-user/linuxload.c b/linux-user/linuxload.c
-index a27e1d0..eccf8db 100644
+index a27e1d0..f726930 100644
 --- a/linux-user/linuxload.c
 +++ b/linux-user/linuxload.c
-@@ -45,9 +45,6 @@ static int prepare_binprm(struct linux_binprm *bprm)
+@@ -45,9 +45,10 @@ static int prepare_binprm(struct linux_binprm *bprm)
      if(!S_ISREG(mode)) {	/* Must be regular file */
          return(-EACCES);
      }
 -    if(!(mode & 0111)) {	/* Must have at least one execute bit set */
 -        return(-EACCES);
 -    }
++    // we cannot set x bits in HOME, ignore check on OHOS
++    // if(!(mode & 0111)) {	/* Must have at least one execute bit set */
++    //     return(-EACCES);
++    // }
  
      bprm->e_uid = geteuid();
      bprm->e_gid = getegid();
 diff --git a/linux-user/signal.c b/linux-user/signal.c
-index 8cf51ff..8fc7532 100644
+index 8cf51ff..815e162 100644
 --- a/linux-user/signal.c
 +++ b/linux-user/signal.c
-@@ -38,7 +38,6 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
+@@ -38,7 +38,8 @@ static void host_signal_handler(int host_signum, siginfo_t *info,
   * Signal number 0 is reserved for use as kill(pid, 0), to test whether
   * a process exists without sending it a signal.
   */
 -QEMU_BUILD_BUG_ON(__SIGRTMAX + 1 != _NSIG);
++// FIXME
++// QEMU_BUILD_BUG_ON(__SIGRTMAX + 1 != _NSIG);
  static uint8_t host_to_target_signal_table[_NSIG] = {
      [SIGHUP] = TARGET_SIGHUP,
      [SIGINT] = TARGET_SIGINT,
-@@ -222,7 +221,6 @@ int do_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
+@@ -222,7 +223,8 @@ int do_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
  
          switch (how) {
          case SIG_BLOCK:
 -            sigorset(&ts->signal_mask, &ts->signal_mask, set);
++            // unavailable on OHOS
++            // sigorset(&ts->signal_mask, &ts->signal_mask, set);
              break;
          case SIG_UNBLOCK:
              for (i = 1; i <= NSIG; ++i) {
-@@ -953,8 +951,6 @@ static void handle_pending_signal(CPUArchState *cpu_env, int sig,
-     } else if (handler == TARGET_SIG_ERR) {
+@@ -954,7 +956,8 @@ static void handle_pending_signal(CPUArchState *cpu_env, int sig,
          dump_core_and_abort(sig);
      } else {
--        /* compute the blocked signals during the handler execution */
+         /* compute the blocked signals during the handler execution */
 -        sigset_t *blocked_set;
++        // sigorset unavailable on OHOS
++        // sigset_t *blocked_set;
  
          target_to_host_sigset(&set, &sa->sa_mask);
          /* SA_NODEFER indicates that the current signal should not be
-@@ -966,10 +962,6 @@ static void handle_pending_signal(CPUArchState *cpu_env, int sig,
-            end of the signal execution (see do_sigreturn) */
+@@ -967,9 +970,10 @@ static void handle_pending_signal(CPUArchState *cpu_env, int sig,
          host_to_target_sigset_internal(&target_old_set, &ts->signal_mask);
  
--        /* block signals in the handler */
+         /* block signals in the handler */
 -        blocked_set = ts->in_sigsuspend ?
 -            &ts->sigsuspend_mask : &ts->signal_mask;
 -        sigorset(&ts->signal_mask, blocked_set, &set);
++        // sigorset unavailable on OHOS
++        // blocked_set = ts->in_sigsuspend ?
++        //     &ts->sigsuspend_mask : &ts->signal_mask;
++        // sigorset(&ts->signal_mask, blocked_set, &set);
          ts->in_sigsuspend = 0;
  
          /* if the CPU is in VM86 mode, we restore the 32 bit values */
 diff --git a/linux-user/syscall.c b/linux-user/syscall.c
-index 05f0391..1351c7e 100644
+index 05f0391..81574f9 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
-@@ -6188,8 +6188,6 @@ static int target_to_host_fcntl_cmd(int cmd)
+@@ -6183,13 +6183,12 @@ static int target_to_host_fcntl_cmd(int cmd)
+     return ret;
+ }
+ 
++// F_EXLCK & F_SHLCK removed for OHOS
+ #define FLOCK_TRANSTBL \
+     switch (type) { \
      TRANSTBL_CONVERT(F_RDLCK); \
      TRANSTBL_CONVERT(F_WRLCK); \
      TRANSTBL_CONVERT(F_UNLCK); \
@@ -147,20 +188,28 @@ index 05f0391..1351c7e 100644
      }
  
  static int target_to_host_flock(int type)
-@@ -6791,7 +6789,6 @@ static inline abi_long target_to_host_sigevent(struct sigevent *host_sevp,
+@@ -6791,7 +6790,8 @@ static inline abi_long target_to_host_sigevent(struct sigevent *host_sevp,
      host_sevp->sigev_signo =
          target_to_host_signal(tswap32(target_sevp->sigev_signo));
      host_sevp->sigev_notify = tswap32(target_sevp->sigev_notify);
 -    host_sevp->_sigev_un._tid = tswap32(target_sevp->_sigev_un._tid);
++    // missing on OHOS
++    // host_sevp->_sigev_un._tid = tswap32(target_sevp->_sigev_un._tid);
  
      unlock_user_struct(target_sevp, target_addr, 1);
      return 0;
-@@ -9513,8 +9510,6 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+@@ -9513,8 +9513,9 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
          }
          return ret;
  #endif
 -    case TARGET_NR_vhangup:
 -        return get_errno(vhangup());
++    // missing on OHOS
++    // case TARGET_NR_vhangup:
++    //     return get_errno(vhangup());
  #ifdef TARGET_NR_syscall
      case TARGET_NR_syscall:
          return do_syscall(cpu_env, arg1 & 0xffff, arg2, arg3, arg4, arg5,
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu/0002-Handle-target-madvise.patch
+++ b/build-hnp/qemu/0002-Handle-target-madvise.patch
@@ -1,8 +1,23 @@
+From acc9ae6bf271caee6b0f92f4fbe1d0838aa3e11f Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sun, 6 Jul 2025 01:39:48 +0800
+Subject: [PATCH 2/5] Handle target madvise
+
+---
+ accel/tcg/translate-all.c |  8 +++++--
+ bsd-user/mmap.c           |  8 +++----
+ include/exec/cpu-all.h    | 11 ++++++++-
+ linux-user/elfload.c      |  2 +-
+ linux-user/mmap.c         | 49 +++++++++++++++++++++++++++++++++++----
+ linux-user/qemu.h         |  1 +
+ linux-user/syscall.c      | 12 ++++------
+ 7 files changed, 71 insertions(+), 20 deletions(-)
+
 diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
-index b0d1ec7..e02da31 100644
+index 45b1918..b7cccc3 100644
 --- a/accel/tcg/translate-all.c
 +++ b/accel/tcg/translate-all.c
-@@ -2490,7 +2490,8 @@ int page_get_flags(target_ulong address)
+@@ -2491,7 +2491,8 @@ int page_get_flags(target_ulong address)
  /* Modify the flags of a page and invalidate the code if necessary.
     The flag PAGE_WRITE_ORG is positioned automatically depending
     on PAGE_WRITE.  The mmap_lock should already be held.  */
@@ -12,7 +27,7 @@ index b0d1ec7..e02da31 100644
  {
      target_ulong addr, len;
  
-@@ -2522,7 +2523,10 @@ void page_set_flags(target_ulong start, target_ulong end, int flags)
+@@ -2523,7 +2524,10 @@ void page_set_flags(target_ulong start, target_ulong end, int flags)
              p->first_tb) {
              tb_invalidate_phys_page(addr, 0);
          }
@@ -95,7 +110,7 @@ index 49384bb..8673a79 100644
  #endif
  
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 558df4d..d3b4548 100644
+index dea50b1..4832a39 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1847,7 +1847,7 @@ static void zero_bss(abi_ulong elf_bss, abi_ulong last_bss, int prot)
@@ -211,7 +226,7 @@ index 792c742..2df9da3 100644
  extern abi_ulong mmap_next_start;
  abi_ulong mmap_find_vma(abi_ulong, abi_ulong, abi_ulong);
 diff --git a/linux-user/syscall.c b/linux-user/syscall.c
-index 1351c7e..19c5dc7 100644
+index 81574f9..c7e8425 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
 @@ -4316,7 +4316,8 @@ static inline abi_ulong do_shmat(CPUArchState *cpu_env,
@@ -234,7 +249,7 @@ index 1351c7e..19c5dc7 100644
              break;
          }
      }
-@@ -11319,11 +11321,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+@@ -11325,11 +11327,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
  
  #ifdef TARGET_NR_madvise
      case TARGET_NR_madvise:
@@ -247,3 +262,6 @@ index 1351c7e..19c5dc7 100644
  #endif
  #ifdef TARGET_NR_fcntl64
      case TARGET_NR_fcntl64:
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu/0003-Drop-missing-syscall-for-x86_64-on-OHOS.patch
+++ b/build-hnp/qemu/0003-Drop-missing-syscall-for-x86_64-on-OHOS.patch
@@ -1,3 +1,12 @@
+From b82c99bb20cd05d894ff211cea8d057d85bd8672 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sun, 6 Jul 2025 01:40:06 +0800
+Subject: [PATCH 3/5] Drop missing syscall for x86_64 on OHOS
+
+---
+ linux-user/x86_64/syscall_64.tbl | 7 -------
+ 1 file changed, 7 deletions(-)
+
 diff --git a/linux-user/x86_64/syscall_64.tbl b/linux-user/x86_64/syscall_64.tbl
 index 44d510b..90ea8b4 100644
 --- a/linux-user/x86_64/syscall_64.tbl
@@ -23,3 +32,6 @@ index 44d510b..90ea8b4 100644
  528	x32	kexec_load		__x32_compat_sys_kexec_load
  529	x32	waitid			__x32_compat_sys_waitid
  530	x32	set_robust_list		__x32_compat_sys_set_robust_list
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu/0004-Drop-PROT_EXEC-for-mmap-on-OHOS.patch
+++ b/build-hnp/qemu/0004-Drop-PROT_EXEC-for-mmap-on-OHOS.patch
@@ -1,8 +1,17 @@
+From bdc5ec193a7366d5ba3a1afeb7fe5a9c847bf117 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Sun, 6 Jul 2025 01:40:32 +0800
+Subject: [PATCH 4/5] Drop PROT_EXEC for mmap on OHOS
+
+---
+ linux-user/syscall.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
 diff --git a/linux-user/syscall.c b/linux-user/syscall.c
-index 19c5dc7..3a376f1 100644
+index c7e8425..0e9cc55 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
-@@ -9116,10 +9116,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+@@ -9119,10 +9119,13 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
                                          v5, v6));
          }
  #else
@@ -17,3 +26,6 @@ index 19c5dc7..3a376f1 100644
  #endif
          return ret;
  #endif
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu/0005-Enable-jit.patch
+++ b/build-hnp/qemu/0005-Enable-jit.patch
@@ -1,0 +1,62 @@
+From 51f38935654105f22e8c40d3a99d980ae6054f27 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Tue, 29 Jul 2025 09:17:37 +0800
+Subject: [PATCH 5/5] Enable jit
+
+---
+ accel/tcg/translate-all.c | 16 +++++++++++++++-
+ include/qemu/osdep.h      |  5 +++++
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/accel/tcg/translate-all.c b/accel/tcg/translate-all.c
+index b7cccc3..e4ab10c 100644
+--- a/accel/tcg/translate-all.c
++++ b/accel/tcg/translate-all.c
+@@ -1041,13 +1041,27 @@ static inline void *alloc_code_gen_buffer(void)
+ #else
+ static inline void *alloc_code_gen_buffer(void)
+ {
+-    // avoid PROT_EXEC on OHOS
++#if !defined(CONFIG_TCG_INTERPRETER)
++    int prot = PROT_WRITE | PROT_READ | PROT_EXEC;
++#else
+     int prot = PROT_WRITE | PROT_READ;
++#endif
+     int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+     size_t size = tcg_ctx->code_gen_buffer_size;
+     void *buf;
+ 
++#if !defined(CONFIG_TCG_INTERPRETER)
++    //  required by OHOS
++    prctl(PRCTL_SET_JITFORT, 0, 0);
++#endif
++
+     buf = mmap(NULL, size, prot, flags, -1, 0);
++
++#if !defined(CONFIG_TCG_INTERPRETER)
++    //  required by OHOS
++    prctl(PRCTL_SET_JITFORT, 0, 1);
++#endif
++
+     if (buf == MAP_FAILED) {
+         return NULL;
+     }
+diff --git a/include/qemu/osdep.h b/include/qemu/osdep.h
+index 1866cab..077a272 100644
+--- a/include/qemu/osdep.h
++++ b/include/qemu/osdep.h
+@@ -115,6 +115,11 @@ extern int daemon(int, int);
+ #define WEXITSTATUS(x) (x)
+ #endif
+ 
++#if !defined(CONFIG_TCG_INTERPRETER)
++#include <sys/prctl.h>
++#define PRCTL_SET_JITFORT   0x6a6974
++#endif
++
+ #ifdef _WIN32
+ #include "sysemu/os-win32.h"
+ #endif
+-- 
+2.49.0.windows.1
+

--- a/build-hnp/qemu/Makefile
+++ b/build-hnp/qemu/Makefile
@@ -4,17 +4,18 @@ all: download/qemu-5.0
 	rm -rf temp build
 	mkdir -p temp build/bin
 	cd download/qemu-5.0 && git worktree add -f $(shell pwd)/temp/qemu-5.0 HEAD
-	cd temp/qemu-5.0 && git apply ../../0001_port_to_ohos.patch
-	cd temp/qemu-5.0 && git apply ../../0002_fix_madvise.patch
-	cd temp/qemu-5.0 && git apply ../../0003_support_x86_64.patch
-	cd temp/qemu-5.0 && git apply ../../0004_disable_mmap_PROT_EXEC.patch
+	cd temp/qemu-5.0 && git apply ../../0001-Initial-porting-to-OHOS.patch
+	cd temp/qemu-5.0 && git apply ../../0002-Handle-target-madvise.patch
+	cd temp/qemu-5.0 && git apply ../../0003-Drop-missing-syscall-for-x86_64-on-OHOS.patch
+	cd temp/qemu-5.0 && git apply ../../0004-Drop-PROT_EXEC-for-mmap-on-OHOS.patch
+	cd temp/qemu-5.0 && git apply ../../0005-Enable-jit.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \
 	PKG_CONFIG_LIBDIR=$(shell pwd)/../sysroot/lib/pkgconfig:$(shell pwd)/../sysroot/share/pkgconfig \
 	PKG_CONFIG_SYSROOT_DIR=$(shell pwd)/../sysroot \
 	CFLAGS="-D_UAPI_LINUX_VIRTIO_VSOCK_H -D_UAPI_LINUX_VIRTIO_TYPES_H -D_UAPI_LINUX_VIRTIO_RING_H -D_UAPI_LINUX_VIRTIO_PMEM_H -D_UAPI_LINUX_VIRTIO_NET_H -D_UAPI_LINUX_VIRTIO_IOMMU_H -D_UAPI_LINUX_VIRTIO_FS_H -D_UAPI_LINUX_VIRTIO_CONSOLE_H -D_UAPI_LINUX_VIRTIO_CONFIG_H -D_LINUX_SYSINFO_H -D__user= -D__force= ${CFLAGS} -I$(shell pwd)/../sysroot/include/glib-2.0 -I$(shell pwd)/../sysroot/lib/glib-2.0/include -L$(shell pwd)/../sysroot/lib" \
-	./configure --target-list=aarch64-linux-user,x86_64-linux-user --cross-prefix= --host-cc=cc --disable-kvm --disable-xen --disable-docs --disable-system --enable-tcg-interpreter --disable-werror
+	./configure --target-list=aarch64-linux-user,x86_64-linux-user --cross-prefix= --host-cc=cc --disable-kvm --disable-xen --disable-docs --disable-system --disable-werror
 	cd temp/qemu-5.0 && make -j $(shell nproc)
 	cp temp/qemu-5.0/aarch64-linux-user/qemu-aarch64 ./build/bin/
 	cp temp/qemu-5.0/x86_64-linux-user/qemu-x86_64 ./build/bin/


### PR DESCRIPTION
Enable jit of qemu according to https://github.com/TermonyHQ/Termony/issues/50 , python launches faster than before.

A simple example in qemu-vroot-aarch64 as following.

With jit:

![1f73390857f84c4b9fd50c37d59d060b](https://github.com/user-attachments/assets/9d9115f0-1415-4858-80f1-6c0d9f5f5eee)

Without jit:

![caec097ee12056a9a52da239c4aa7e7e](https://github.com/user-attachments/assets/08103cbe-97dc-4240-804f-1b97c7eeaa33)